### PR TITLE
partition_manager: Fix incorrect logic in flash_map_pm.h

### DIFF
--- a/include/flash_map_pm.h
+++ b/include/flash_map_pm.h
@@ -30,6 +30,7 @@
 #endif
 
 #define PM_ID(label) PM_##label##_ID
+#define PM_IS_ENABLED(label) PM_##label##_IS_ENABLED
 
 #define FLASH_AREA_ID(label) PM_ID(label)
 
@@ -40,6 +41,6 @@
 	UTIL_CAT(PM_, UTIL_CAT(UTIL_CAT(PM_, UTIL_CAT(PM_ID(label), _LABEL)), _SIZE))
 
 #define FLASH_AREA_LABEL_EXISTS(label) \
-	IS_ENABLED(FLASH_AREA_SIZE(label))
+	IS_ENABLED(PM_IS_ENABLED(label))
 
 #endif /* FLASH_MAP_PM_H_*/

--- a/scripts/partition_manager_output.py
+++ b/scripts/partition_manager_output.py
@@ -61,6 +61,8 @@ def get_config_lines(gpm_config, greg_config, head, split, dest, current_domain=
                 add_line("%s_ID" % name.upper(), "%d" % partition_id)
                 # Used to support lowercase access. See flash_map.h.
                 add_line("%s_ID" % name.lower(), "PM_%s_ID" % name.upper())
+                # Used for IS_ENABLED access, see flash_map_pm.h
+                add_line("%s_IS_ENABLED" % name.lower(), "1")
 
                 if current_domain is None or domain == current_domain:
                     add_line("%d_LABEL" % partition_id, "%s" % name.upper())


### PR DESCRIPTION
The 'FLASH_AREA_EXISTS' macro did not work.
Add IS_ENABLED logic to be aligned with how the upstream flash_map.h
works.

Ref: NCSDK-7148
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>