### PR TITLE
applications: asset_tracker: set CONFIG_INIT_ARCH_HW_AT_BOOT for SPM

### DIFF
--- a/applications/asset_tracker/spm.conf
+++ b/applications/asset_tracker/spm.conf
@@ -5,3 +5,9 @@ CONFIG_GPIO=n
 
 # Make watchdog timers non-secure (so they can be used in the non-secure image).
 CONFIG_SPM_NRF_WDT_NS=y
+
+# Images that set CONFIG_BOOTLOADER_MCUBOOT get this value set by default.
+# The SPM image will not have CONFIG_BOOTLOADER_MCUBOOT set by default when
+# being built by a parent image. Hence we set it here to ensure that SPM
+# cleans up the core during boot.
+CONFIG_INIT_ARCH_HW_AT_BOOT=y


### PR DESCRIPTION
Same as in the core SPM config file.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>