### PR TITLE
samples: nrf9160: lwm2m_client: Fix build warning

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -354,6 +354,10 @@ static void rd_client_event(struct lwm2m_ctx *client,
 	case LWM2M_RD_CLIENT_EVENT_QUEUE_MODE_RX_OFF:
 		LOG_DBG("Queue mode RX window closed");
 		break;
+
+	case LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR:
+		LOG_ERR("LwM2M engine reported a network erorr.");
+		break;
 	}
 }
 


### PR DESCRIPTION
Handle new enum from upstream. For now just log the event.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>